### PR TITLE
Update the relevant markdown documents of alto

### DIFF
--- a/group/ALTO.md
+++ b/group/ALTO.md
@@ -1,85 +1,81 @@
 ---
-title: ALTO Working Group
-description: 
+title: The ALTO Working Group
+description: The wiki page for the Application-Layer Traffic Optimization Working Group
 published: true
-date: 2022-10-18T13:38:59.986Z
-tags: 
+date: 2022-10-25T14:18:52.324Z
+tags:
 editor: markdown
-dateCreated: 2022-10-18T13:36:24.895Z
+dateCreated: 2022-10-18T13:40:31.135Z
 ---
 
-# The ALTO Implementation and Deployment Survey 
+# ALTO Datatracker
+
+https://datatracker.ietf.org/wg/alto/about/
+
+# The ALTO Implementation and Deployment Survey
 
 [Known Implementation/Deployments of the ALTO protocol](/en/group/ALTO/deployment)
 
 # The Application Layer Traffic Optimization (ALTO) Wiki
 
-The WG is using [the Github dashborad](https://github.com/orgs/ietf-wg-alto/projects/1/views/2) to organize the agenda of weekly meetings.
+The WG is using [the Github dashborad](https://github.com/orgs/ietf-wg-alto/projects/1/views/2) to organize the agenda
+of weekly meetings.
 
-<!-- TODO: create the pages
-[wiki:v0.5-recharter Draft re-charter (version 0.5 May 8 2021)]
-
-[wiki:v0.4-recharter Draft re-charter (version 0.4 April 1 2021)]
-
-[wiki:v0.3-recharter Draft re-charter (version 0.3 March 18 2021)]
-
-[wiki:v0.2-recharter Draft re-charter (version 0.2, Feb 22 2021)]
-
-[wiki:v0.1-recharter Draft re-charter (version 0.1, Feb 21 2014)]
-
-[wiki:v0.0-recharter Draft re-charter (version 0.0, Feb 19 2014)]
--->
+- [Draft re-charter (version 0.5 May 8 2021)](/en/group/ALTO/draft/v0.5-recharter)
+- [Draft re-charter (version 0.4 April 1 2021)](/en/group/ALTO/draft/v0.4-recharter)
+- [Draft re-charter (version 0.3 March 18 2021)](/en/group/ALTO/draft/v0.3-recharter)
+- [Draft re-charter (version 0.2, Feb 22 2021)](/en/group/ALTO/draft/v0.2-recharter)
+- [Draft re-charter (version 0.1, Feb 21 2014)](/en/group/ALTO/draft/v0.1-recharter)
+- [Draft re-charter (version 0.0, Feb 19 2014)](/en/group/ALTO/draft/v0.0-recharter)
 
 # Weekly Meeting
 
-Welcome to join us. Subscribe [alto@ietf.org](https://www.ietf.org/mailman/listinfo/alto) or [alto-weekly-meeting@googlegroups.com](https://groups.google.com/forum/#!forum/alto-weekly-meeting) to receive meeting reminder notifications.
+Welcome to join us. Subscribe [alto@ietf.org](https://www.ietf.org/mailman/listinfo/alto)
+or [alto-weekly-meeting@googlegroups.com](https://groups.google.com/forum/#!forum/alto-weekly-meeting) to receive
+meeting reminder notifications.
 
- * Time: 9:00 - 10:00 am ET every Tuesday
- * Bridge: https://yale.zoom.us/my/yryang
- * Meeting Records: [Google drive](https://drive.google.com/drive/folders/1Z845CZmkf9OMnHlVxkEfvbXcSfdm-Fbn?usp=sharing)
- 
+- Time: 9:00 - 10:00 am ET every Tuesday
+- Bridge: https://yale.zoom.us/my/yryang
+- Meeting Records: [Google drive](https://drive.google.com/drive/folders/1Z845CZmkf9OMnHlVxkEfvbXcSfdm-Fbn?usp=sharing)
 
 # Coming Meetings
 
-* [IETF 115](https://www.ietf.org/how/meetings/115/) (November 5-11, 2022; London, UK)
- 
+- [IETF 115](https://www.ietf.org/how/meetings/115/) (November 5-11, 2022; London, UK)
+
 # Recent Meetings
 
-* [ALTO session in IETF 110](https://www.youtube.com/watch?v=fjBSODKtuLA)
-* [ALTO session in IETF 109](https://www.youtube.com/watch?v=ldduoGYGqRg&t=6131s)
-* [ALTO session in IETF 108](https://www.youtube.com/watch?v=0VGbj8IGxzw)
-* ATLO session in IETF 107 was cancelled
-* [ALTO session in IETF 106](https://www.youtube.com/watch?v=En64HisRFoQ)
-* ANI side meeting in IETF 106 (slides) [Dropbox](https://www.dropbox.com/sh/8xamtujadex7idl/AAAujFZxfVZnpMVGNk3Yu5t5a?dl=0) [Google Drive](https://drive.google.com/open?id=1uhZ7ZHGtMjcGebBlC0SBavTMwECdqeIp)
+- [ALTO session in IETF 110](https://www.youtube.com/watch?v=fjBSODKtuLA)
+- [ALTO session in IETF 109](https://www.youtube.com/watch?v=ldduoGYGqRg&t=6131s)
+- [ALTO session in IETF 108](https://www.youtube.com/watch?v=0VGbj8IGxzw)
+- ATLO session in IETF 107 was cancelled
+- [ALTO session in IETF 106](https://www.youtube.com/watch?v=En64HisRFoQ)
+- ANI side meeting in IETF 106 (
+  slides) [Dropbox](https://www.dropbox.com/sh/8xamtujadex7idl/AAAujFZxfVZnpMVGNk3Yu5t5a?dl=0) [Google Drive](https://drive.google.com/open?id=1uhZ7ZHGtMjcGebBlC0SBavTMwECdqeIp)
 
-<!-- TODO
-== Past Meeting Notes, Slides and Audio Files ==
+# Past Meeting Notes, Slides and Audio Files
 
- * [https://datatracker.ietf.org/wg/alto/meetings/ IETF meetings in recent past 10 years]
- * [wiki:Ietf97 IETF97 (November 2016 - Seoul, Korea)]
- * [wiki:Ietf96 IETF96 (July 2016 - Berlin, Germany)]
- * [wiki:Ietf95 IETF95 (April 2016 - Buenos Aires,Argentina)]
- * [wiki:Ietf94 IETF94 (November 2015 - Yokohama, Japan)]
- * [wiki:Ietf93 IETF93 (July 2015 - Prague, Czech)]
- * [wiki:Ietf92 IETF92 (March 2015 - Dallas, USA)]
- * [wiki:Ietf91 IETF91 (November 2014 -Hawaii, USA)]
- * [wiki:Ietf90 IETF90 (July 2014 -Toronto, Canada)]
- * [wiki:Ietf89 IETF89 (March 2014 - London, UK)]
- * [wiki:Ietf88 IETF88 (November 2013 - Vancouver, Canada)]
- * [wiki:Ietf87 IETF87 (July 2013 - Berlin, Germany)]
- * [wiki:Ietf86 IETF86 (March 2013 - Orlando, USA)]
- * [wiki:Ietf85 IETF85 (November 2012 - Atlanta, USA)]
- * [wiki:Ietf84 IETF84 (July 2012 -Vancouver,Canada)]
- * [wiki:Ietf83 IETF83 (March 2012 - Paris, France)]
- * [wiki:Ietf82 IETF82 (November 2011 - Taipei, Taiwan)]
- * [wiki:Ietf81 IETF 81 (July 2011 - Quebec, Canada)]
- * [wiki:Ietf80 IETF 80 (March 2011 - Prague,Czech)]
- * [wiki:Ietf79 IETF 79 (November 2010 - Beijing, China)]
- * [wiki:Ietf78 IETF 78 (July 2010 - Maastricht, Netherlands)]
- * [wiki:Interim20100616 Virtual Interim Meeting, June 16, 2010]
- * [wiki:Ietf77 IETF 77 (March 2010 - Anaheim, CA)]
- * [wiki:Ietf76 IETF 76 (November 2009 - Hiroshima, Japan)]
- * [wiki:Ietf75 IETF 75 (July 2009 - Stockholm, Sweden)]
- * [wiki:Ietf74 IETF 74 (March 2009 - San Francisco, CA)]
- * [wiki:Ietf73 IETF 73 (November 2008 - Minneapolis, MN)]
--->
+- [IETF97 (November 2016 - Seoul, Korea)](/en/group/ALTO/past-meetings/97)
+- [IETF96 (July 2016 - Berlin, Germany)](/en/group/ALTO/past-meetings/96)
+- [IETF95 (April 2016 - Buenos Aires,Argentina)](/en/group/ALTO/past-meetings/95)
+- [IETF94 (November 2015 - Yokohama, Japan)](/en/group/ALTO/past-meetings/94)
+- [IETF93 (July 2015 - Prague, Czech)](/en/group/ALTO/past-meetings/93)
+- [IETF92 (March 2015 - Dallas, USA)](/en/group/ALTO/past-meetings/92)
+- [IETF91 (November 2014 -Hawaii, USA)](/en/group/ALTO/past-meetings/91)
+- Ietf90 IETF90 (July 2014 -Toronto, Canada)
+- Ietf89 IETF89 (March 2014 - London, UK)
+- Ietf88 IETF88 (November 2013 - Vancouver, Canada)
+- Ietf87 IETF87 (July 2013 - Berlin, Germany)
+- Ietf86 IETF86 (March 2013 - Orlando, USA)
+- Ietf85 IETF85 (November 2012 - Atlanta, USA)
+- Ietf84 IETF84 (July 2012 -Vancouver,Canada)
+- Ietf83 IETF83 (March 2012 - Paris, France)
+- Ietf82 IETF82 (November 2011 - Taipei, Taiwan)
+- Ietf81 IETF 81 (July 2011 - Quebec, Canada)
+- Ietf80 IETF 80 (March 2011 - Prague,Czech)
+- [IETF 79 (November 2010 - Beijing, China)](/en/group/ALTO/past-meetings/79)
+- [IETF 78 (July 2010 - Maastricht, Netherlands)](/en/group/ALTO/past-meetings/78)
+- [Virtual Interim Meeting, June 16, 2010](/en/group/ALTO/past-meetings/Interim20100616)[IETF 77 (March 2010 - Anaheim, CA)](/en/group/ALTO/past-meetings/77)
+- [IETF 76 (November 2009 - Hiroshima, Japan)](/en/group/ALTO/past-meetings/76)
+- [IETF 75 (July 2009 - Stockholm, Sweden)](/en/group/ALTO/past-meetings/75)
+- [IETF 74 (March 2009 - San Francisco, CA)](/en/group/ALTO/past-meetings/74)
+- [IETF 73 (November 2008 - Minneapolis, MN)](/en/group/ALTO/past-meetings/73)

--- a/group/ALTO/draft/v00.md
+++ b/group/ALTO/draft/v00.md
@@ -1,0 +1,55 @@
+---
+title: Draft re-charter (version 0.0, Feb 19
+  2014)
+description:
+published: true
+date: 2022-10-26T21:13:02.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter
+
+The ALTO working group was established in 2008 to devise a request/
+response protocol for allowing a host to benefit from a server that is
+more cognizant of the network infrastructure than the host would be.
+The working group has developed an HTTP-based protocol (RFC-to-be) to
+allow hosts to benefit from the network infrastructure by having
+access to a pair of maps: a topology map and a cost map.
+
+The origins of the ALTO protocol lay in peer-to-peer (P2P)
+applications, where the host was a peer in a P2P network and desired
+to be rendezvoused with other peers for file sharing, real-time
+communications, etc. It is a testament to the flexibility of the ALTO
+protocol that it is now being considered as a solution for problems
+outside the P2P domain, such as in datacenter networks and in content
+distribution networks (CDN) where exposing abstract topologies helps
+applications.
+
+To support the emerging new uses of ALTO, certain extensions are being
+sought. These extensions can be classified as follows:
+
+    - (Standards Track) Protocol extensions for reducing the volume of on-the-wire data exchange required to align the ALTO server and clients Extensions under consideration are mechanisms for delivering server-initiated notifications and partial updates of maps. Efforts developed in other working groups such as Websockets and JSON-path will be considered, as well as bespoke mechanisms specific to the ALTO protocol.
+
+    - (Standards Track) Extensions to the base ALTO server discovery mechanism (RFC-to-be) for deployment in heterogeneous network environments. Mechanisms under consideration are extensions for third-party and anycast-based server discovery.
+
+    - (Standards Track) Protocol extensions to convey a richer set of attributes to allow applications to determine not only "where" to connect but also "when" to connect. Such additional information will be related both to endpoints (e.g. conveying server load and cache geo-location information for CDN use cases) and to endpoint-to-endpoint costs (e.g. bandwidth calendaring to represent time-averaged cost values in datacenter networks).
+      The working group will specify such extension in coordination with other working groups that are also working on the related use cases (e.g. cdni, i2rs, lmap).
+
+    - (Informational) A survey of techniques to formalize the structure of a network graph (that can derived from a set of related ALTO network and cost maps) in a format that would facilitate advanced graph computation. Such survey will cover both models used in popular open-source software (e.g. NetworkX, Blueprints) and models being considered in other working groups (e.g. netmod, i2rs).
+
+    - (Informational) An document on deployment-related issues and lessons learned from early implementation   experiences.
+      When the WG considers standardizing information that the ALTO server could provide, the following criteria are important to ensure real feasibility:
+
+- Can the ALTO service realistically discover that information?
+
+- Is the distribution of that information allowed by the operators of that service?
+
+- Can a client get that information without excessive privacy concerns? Extensions defining new endpoint properties should focus on exposing attributes of endpoints that are related to the goals of ALTO -- optimization of application-layer traffic -- as opposed to more general properties of endpoints. Privacy aspects of new endpoint properties will in any case be evaluated to the guidelines provided in the IANA considerations and Security Considerations of the ALTO protocol specification (RFC-to-be, sections 14.3 and 15.4 at IESG review time).
+
+- Is it information that a client cannot find easily some other way? After these criteria are met, the importance of the data will be considered for prioritizing standardization work, for example the number of operators and clients that are likely to be able to provide or use that particular data. In any case, this WG will not propose standards on how congestion is signaled, remediated, or avoided, and will not deal with information representing instantaneous network state. Issues related to the specific content exchanged in systems that make use of ALTO are also excluded from the WG's scope, as is the issue dealing with enforcing the legality of the content.
+
+Milestones
+
+Jul 2014 Working Group Last Call for third-party server discovery document Jul 2014 Working Group Last Call for anycast-based server discovery document July 2014 Working Group Last Call for partial updates document Sep 2014 Submit third-party server discovery document Sep 2014 Submit anycast-based server discovery document Sep 2014 Submit partial updates document Sep 2014 Working Group Last Call for deployment considerations document Sep 2014 Working Group Last Call for network graph format survey document Nov 2014 Submit deployment considerations document Nov 2014 Submit network graph format survey document Nov 2014 Working Group Last Call for server-initiated notifications document Jan 2015 Submit server-initiated notifications document Jan 2015 Working Group Last Call for endpoint property extension document Jan 2015 Working Group Last Call for cost property extension document Mar 2015 Submit endpoint property extension document Mar 2015 Submit cost property extension document

--- a/group/ALTO/draft/v01.md
+++ b/group/ALTO/draft/v01.md
@@ -1,0 +1,87 @@
+---
+title: Draft re-charter (version 0.1, Feb 21
+  2014)
+description:
+published: true
+date: 2022-10-26T21:13:01.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter
+
+The ALTO working group was established in 2008 to devise a request/response protocol for allowing a host to benefit from a server that is more cognizant of the network infrastructure than the host would be. The working group has developed an HTTP-based protocol (RFC-to-be) to allow hosts to benefit from the network infrastructure by having access to a pair of maps: a topology map and a cost map.
+
+The origins of the ALTO protocol lie in peer-to-peer (P2P) applications, where the host is a peer in a P2P network and desires a rendezvous with other peers for file sharing, real-time communications, etc. It is a testament to the flexibility of the ALTO protocol that it is now being considered as a solution for problems outside the P2P domain, such as in datacenter networks and in content distribution networks (CDN) where exposing abstract topologies helps applications.
+
+To support the emerging new uses of ALTO, certain extensions are being sought. These extensions can be classified as follows:
+
+    - (Standards Track) Protocol extensions for reducing the volume on-the-wire data exchange required to align the ALTO server and clients. Extensions under consideration are mechanisms for delivering server-initiated notifications and partial updates of maps. Efforts developed in other working groups such as Websockets and JSON-patch will be considered, as well as bespoke mechanisms specific to the ALTO protocol.
+    - (Standards Track) Extensions to the base ALTO server discov mechanism (RFC-to-be) for deployment in heterogeneous network environments. Mechanisms under consideration are extensions for third-party and anycast-based server discovery.
+    - (Standards Track) Protocol extensions to convey a richer set attributes to allow applications to determine not only "where" to connect but also "when" to connect. Such additional information will be related both to endpoints (e.g. conveying server load and cache geo-location information for CDN use cases) and to endpoint-to-endpoint costs (e.g. bandwidth calendaring to represent time-averaged cost values in datacenter networks).
+    - The working group will specify such extension in coordination with other working groups that are also working on the related use cases (e.g. cdni, i2rs, lmap).
+    - (Informational) A survey of techniques to formalize the struct of a network graph (that can derived from a set of related ALTO network and cost maps) in a format that would facilitate advanced graph computation. Such survey will cover both models used in popular open-source software (e.g. NetworkX, Blueprints) and models being considered in other working groups (e.g. netmod, i2rs).
+    - (Informational) An document on deployment-related issues lessons learned from early implementation experiences.
+
+When the WG considers standardizing information that the ALTO server
+could provide, the following criteria are important to ensure real
+feasibility:
+
+- Can the ALTO service realistically discover that information?
+- Is the distribution of that information allowed by the operators of
+  that service?
+- Can a client get that information without excessive privacy concerns? Extensions defining new endpoint properties should focus on exposing attributes of endpoints that are related to the goals of ALTO -- optimization of application-layer traffic -- as opposed to more general properties of endpoints. Privacy aspects of new endpoint properties will in any case be evaluated to the guidelines provided in the IANA considerations and Security Considerations of the ALTO protocol specification (RFC-to-be, sections 14.3 and 15.4 at IESG review time).
+- Is it information that a client cannot find easily some other way?
+
+After these criteria are met, the importance of the data will be considered for prioritizing standardization work, for example the number of operators and clients that are likely to be able to provide or use that particular data. In any case, this WG will not propose standards on how congestion is signaled, remediated, or avoided, and will not deal with information representing instantaneous network state.
+
+Issues related to the specific content exchanged in systems that make
+use of ALTO are also excluded from the WG's scope, as is the issue
+dealing with enforcing the legality of the content.
+
+Milestones
+
+Jul 2014 Working Group Last Call for third-party server discovery
+
+> document
+
+Jul 2014 Working Group Last Call for anycast-based server discovery
+
+> document
+
+Jul 2014 Working Group Last Call for partial updates document
+
+Sep 2014 Submit third-party server discovery document
+
+Sep 2014 Submit anycast-based server discovery document
+
+Sep 2014 Submit partial updates document
+
+Sep 2014 Working Group Last Call for deployment considerations
+
+> document
+
+Sep 2014 Working Group Last Call for network graph format survey
+
+> document
+
+Nov 2014 Submit deployment considerations document
+
+Nov 2014 Submit network graph format survey document
+
+Nov 2014 Working Group Last Call for server-initiated notifications
+
+> document
+
+Jan 2015 Submit server-initiated notifications document
+
+Jan 2015 Working Group Last Call for endpoint property extension
+
+> document
+
+Jan 2015 Working Group Last Call for cost property extension document
+
+Mar 2015 Submit endpoint property extension document
+
+Mar 2015 Submit cost property extension document

--- a/group/ALTO/draft/v02.md
+++ b/group/ALTO/draft/v02.md
@@ -1,0 +1,48 @@
+---
+title: Draft re-charter (version 0.2, Feb 22
+  2021)
+description:
+published: true
+date: 2022-10-26T21:13:00.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter
+
+The ALTO working group was established in 2008 to devise a request/response protocol to allow a host to benefit from a server that is more cognizant of the network infrastructure than the host is.
+
+The working group has developed an HTTP-based protocol and recent work has reported large-scale deployment of ALTO based solutions supporting applications such as content distribution networks (CDN).
+
+ALTO is now proposed as a component for cloud-based interactive applications, large-scale data analytics, multi-cloud SD-WAN deployment, and distributed computing. In all these cases, exposing network information such as abstract topologies and network function deployment location helps applications.
+
+To support these emerging uses, extensions are needed, and additional functional and architectural features need to be considered as follows:
+
+- Protocol extensions to support a richer and extensible set of policy attributes in ALTO information update request and response. Such policy attributes may indicate information dependency (e.g., ALTO path-cost/QoS properties with dependency on real-time network indications), optimization criteria (e.g., lowest latency/throughput network performance objective), and constraints (e.g., relaxation bound of optimization criteria, domain or network node to be traversed, diversity of paths).
+
+- Protocol extensions for facilitating operational automation tasks and improving transport efficiency. In particular, extensions to provide "pub/sub" mechanisms to allow the client to request and receive a diverse types (such as event-triggered/sporadic, continuous), customized feed of publisher-generated information. Efforts developed in other working groups such as MQTT Publish / Subscribe Architecture, WebSub?, Subscription to YANG Notifications will be considered, and issues such as scalability (e.g., using unicast or broadcast/multicast, and periodicity of object updates) should be considered.
+
+- The working group will investigate the configuration, management, and operation of ALTO systems and may develop suitable data models.
+
+- Extensions to ALTO services to support multi-domain settings. ALTO is currently specified for a single ALTO server in a single administrative domain, but a network may consist of multiple domains and the potential information sources may not be limited to a certain domain. The working group will investigate extending the ALTO framework to (1) specify multi-ALTO-server protocol flow and usage guidelines when an ALTO service involves network paths spanning multiple domains with multiple ALTO servers, and (2) extend or introduce ALTO services allowing east-west interfaces for multiple ALTO server integration and collaboration. The specifications and extensions should use existing services whenever possible. The specifications and extensions should consider realistic complexities including incremental deployment, dynamicity, and security issues such as access control, authorization (e.g., an ALTO server provides information for a network that the server has no authorization), and privacy protection in multi-domain settings.
+
+- The working group will update [RFC 7971](http://tools.ietf.org/html/rfc7971) to provide operational considerations for recent protocol extensions (e.g., cost calendar, unified properties, and path vector) and new extensions that the WG develops. New considerations will include decisions about the set of information resources (e.g., what metrics to use), notification of changes either in proactive or reactive mode (e.g., pull the backend, or trigger just-in-time measurements), aggregation/processing of the collected information (e.g., compute information and network information )according to the clients’ requests, and integration with new transport mechanisms (e.g., HTTP/2 and HTTP/3).
+
+When the WG considers standardizing information that the ALTO server could provide, the following criteria are important to ensure real feasibility:
+
+- Can the ALTO server realistically provide (measure or derive) that information?
+
+- Is it information that the ALTO client cannot find easily some other way?
+
+- Is the distribution of the information allowed by the operator of the network? Does the exposure of the information introduce privacy and information leakage concerns?
+
+Issues related to the specific content exchanged in systems that make use of ALTO are excluded from the WG's scope, as is the issue of dealing with enforcing the legality of the content. The WG will also not propose standards on how congestion is signaled, remediated, or avoided.
+
+> Apr 2021- Submit cdni request routing document to IESG as Proposed Standard
+
+> Apr 2021 - Submit path vector document to IESG as Proposed Standard
+
+> Apr 2021 - Submit alto performance metric document to IESG as Proposed Standard
+
+> Apr 2021 - Submit entity property map document to IESG as Proposed Standard

--- a/group/ALTO/draft/v03.md
+++ b/group/ALTO/draft/v03.md
@@ -1,0 +1,30 @@
+---
+title: Draft re-charter (version 0.3 March 18
+  2021)
+description:
+published: true
+date: 2022-10-26T21:12:59.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter
+
+The ALTO working group was established in 2008 to devise a request/response protocol to allow a host to benefit from a server that is more cognizant of the network infrastructure than the host is.
+
+The working group has developed an HTTP-based protocol and recent work has reported large-scale deployment of ALTO based solutions supporting applications such as content distribution networks (CDN).
+
+To support current and future deployments of ALTO, the working group is chartered for the following activities:
+
+- Provide a place to collect implementation deployment and experience. It is hoped that implementer and deployers of ALTO will report their experiences on the mailing list, and the working group will track implementation and deployment reports on a wiki or in an Internet-Draft.
+
+- Perform protocol maintenance for the existing published protocol. It is anticipated that questions and issues will arise concerning the existing protocol specifications: the working group will develop and publish updates as necessary to resolve any problems that are found. The working group will also help resolve any errata reports that are raised.
+
+- Develop operational support tools for the ALTO protocol. Based on experience from deployments, the advice in [RFC 7971](http://tools.ietf.org/html/rfc7971), and considering the latest opinions and techniques from the Operations and Management Area, the working group will develop tools to configure, operate, and manage the ALTO protocol and networks that use ALTO. This may include YANG models and OAM mechanisms. The working group may also update [RFC 7971](http://tools.ietf.org/html/rfc7971) in the light of new experience and protocol features that were added to ALTO after that RFC was published.
+
+- Support for modern transport protocols. When work on ALTO began, the protocol was supported using HTTP version 1. Since then, the IETF has developed HTTP/2 and more recently HTTP/3 that uses the QUIC transport protocol. The working group will develop any necessary protocol extensions and guidance to support the use of ALTO over HTTP/2 and HTTP/3.
+
+- Security and privacy. The working group will revisit the ALTO architecture and protocol to check that adequate measures for security and privacy exist and can be easily used. This work item might be addressed by discussions and reviews, or might require additional protocol work.
+
+- Future use cases. The working group will provide a forum to discuss possible future use case. The objective of this discussion will be to determine a small set of use cases that have strong support and a realistic chance of implementation and deployment. The working group will not develop protocol extensions for these use cases until it has been re-chartered specifically for that purpose.

--- a/group/ALTO/draft/v04.md
+++ b/group/ALTO/draft/v04.md
@@ -1,0 +1,36 @@
+---
+title: Draft re-charter (version 0.4 April 1
+  2021)
+description:
+published: true
+date: 2022-10-26T21:12:58.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter Update
+
+The ALTO working group was established in 2008 to devise a request/response protocol to allow a host to benefit from a server that is more cognizant of the network infrastructure than the host is.
+
+The working group has developed an HTTP-based protocol and recent work has reported proof-of-concepts of ALTO based solutions supporting applications such as content distribution networks (CDN).
+
+To support current and future deployments of ALTO, the working group is now chartered for the following activities:
+
+- Provide a place to collect implementation deployment and experience. It is hoped that implementer and deployers of ALTO will report their experiences on the mailing list, and the working group will track implementation and deployment reports on a wiki or in an Internet-Draft.
+
+- Perform protocol maintenance for the existing published protocol. It is anticipated that questions and issues will arise concerning the existing protocol specifications: The working group will develop and publish updates as necessary to resolve any interoperability, performance, operational, or security, or privacy problems that arise. The working group will also help resolve any errata reports that are raised. This work item might be addressed by discussions and reviews, or might require additional RFCs.
+
+- Develop operational support tools for the ALTO protocol. Based on experience from deployments, the advice in [RFC 7971](http://tools.ietf.org/html/rfc7971), and considering the latest opinions and techniques from the Operations and Management Area, the working group will develop tools to configure, operate, and manage the ALTO protocol and networks that use ALTO. This may include YANG models and OAM mechanisms. The working group may also update [RFC 7971](http://tools.ietf.org/html/rfc7971) in the light of new experience and protocol features that were added to ALTO after that RFC was published.
+
+- Support for modern transport protocols. When work on ALTO began, the protocol was supported using HTTP version 1. Since then, the IETF has developed HTTP/2 and HTTP/3. The working group will develop any necessary protocol extensions and guidance to support the use of ALTO over HTTP/2 and HTTP/3.
+
+- Future use cases. The working group will provide a forum to discuss possible future use cases. The objective of this discussion will be to determine a small set of use cases that have strong support and a realistic chance of implementation and deployment. The working group will not develop protocol extensions for these use cases until it has been re-chartered specifically for that purpose.
+
+At the conclusion of the OAM and HTTP2/3 deliverables, plus completion of any adopted drafts emerging from the other work items, the working group will close or recharter.
+
+Milestones and Deliverables:
+
+- Conduct a survey of working group participants and the wider community to discover ALTO implementation and deployment experience. Record the results in a publicly visible wiki.
+- Develop and standardize at least one OAM mechanisms to support ALTO including a YANG model for configuration and management of YANG servers.
+- Perform an analysis of ALTO over HTTP/2 and HTTP/3 and publish a support document. Develop any necessary protocol modifications.

--- a/group/ALTO/draft/v05.md
+++ b/group/ALTO/draft/v05.md
@@ -1,0 +1,39 @@
+---
+title: Draft re-charter (version 0.5 May 8 2021)
+description:
+published: true
+date: 2022-10-26T21:12:57.000Z
+tags:
+editor: markdown
+dateCreated: 2022-04-26T13:06:23.000Z
+---
+
+Application-Layer Traffic Optimization Working Group Charter Update
+
+The ALTO working group was established in 2008 to devise a request/response protocol to allow a host to benefit from a server that is more cognizant of the network infrastructure than the host is.
+
+The working group has developed an HTTP-based protocol and recent work has reported proof-of-concepts of ALTO based solutions supporting applications such as content distribution networks (CDN).
+
+To support current and future deployments of ALTO, the working group is now chartered for the following activities:
+
+- Provide a place to collect implementation deployment and experience. It is hoped that implementer and deployers of ALTO will report their experiences on the mailing list, and the working group will track implementation and deployment reports on a wiki or in an Internet-Draft.
+
+- Perform protocol maintenance for the existing published protocol. It is anticipated that questions and issues will arise concerning the existing protocol specifications: The working group will develop and publish updates as necessary to resolve any interoperability, performance, operational, or security, or privacy problems that arise. The working group will also help resolve any errata reports that are raised. This work item might be addressed by discussions and reviews, or might require additional RFCs.
+
+- Develop operational support tools for the ALTO protocol. Based on experience from deployments, the advice in [RFC 7971](http://tools.ietf.org/html/rfc7971), and considering the latest opinions and techniques from the Operations and Management Area, the working group will develop tools to configure, operate, and manage the ALTO protocol and networks that use ALTO. This may include YANG models and OAM mechanisms. The working group may also update [RFC 7971](http://tools.ietf.org/html/rfc7971) in the light of new experience and protocol features that were added to ALTO after that RFC was published.
+
+- Support for modern transport protocols. When work on ALTO began, the protocol was supported using HTTP version 1. Since then, the IETF has developed HTTP/2 and HTTP/3. The working group will develop any necessary protocol extensions and guidance to support the use of ALTO over HTTP/2 and HTTP/3.
+
+- Future use cases. The working group will provide a forum to discuss possible future use cases. The objective of this discussion will be to determine a small set of use cases that have strong support and a realistic chance of implementation and deployment. The working group will not develop protocol extensions for these use cases until it has been re-chartered specifically for that purpose.
+
+At the conclusion of the OAM and HTTP2/3 deliverables, plus completion of any adopted drafts emerging from the other work items, the working group will close or recharter.
+
+Milestones and Deliverables:
+
+- Conduct a survey of working group participants and the wider community to discover ALTO implementation and deployment experience. Record the results in a publicly visible wiki.
+
+- Develop and standardize at least one OAM mechanisms to support ALTO including a YANG model for configuration and management of ALTO servers.
+
+- Perform an analysis of ALTO over HTTP/2 and HTTP/3 and publish a support document. Develop any necessary protocol modifications.
+
+- Report back to the Area Director to identify any use cases that have strong support and a realistic chance of implementation and deployment.

--- a/group/ALTO/past-meetings/73.md
+++ b/group/ALTO/past-meetings/73.md
@@ -1,65 +1,66 @@
 ---
 title: IETF 73 (November 2008 - Minneapolis, MN)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:21.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 73 (November 2008 - Minneapolis, MN)
 
-In IETF 73 we conducted an experiment to better track the face-to-face discussions. In that vein, the audio recording corresponding to each agenda item is provided below to help participants track the specific discussion. Also provided is a link to the specific set of slides used during the discussion, and the official minutes as recorded by the note taker. We hope that this allows loose ends to be tied quickly and open issues to be tracked effectively.  
+In IETF 73 we conducted an experiment to better track the face-to-face discussions. In that vein, the audio recording corresponding to each agenda item is provided below to help participants track the specific discussion. Also provided is a link to the specific set of slides used during the discussion, and the official minutes as recorded by the note taker. We hope that this allows loose ends to be tied quickly and open issues to be tracked effectively.
 
 1. **Administrivia (Chairs)**  
-(1:20 minutes, 625 KBytes)  
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/administrivia.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/administrivia.mp3)   
- No slides.   
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#agenda](http://www.ietf.org/proceedings/08nov/minutes/alto.html#agenda)
-2. **Status of WG (Lisa Dusseault)**   
-(5:21 minutes, 2.44 MBytes)   
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/wg-status.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/wg-status.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-6.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-6.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#status](http://www.ietf.org/proceedings/08nov/minutes/alto.html#status)
-3. **ALTO problem statement (Enrico Marocco)**   
-(11:06 minutes, 5.08 MBytes)   
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/ps.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/ps.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-3.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-3.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#ps](http://www.ietf.org/proceedings/08nov/minutes/alto.html#ps)
-4. **ALTO requirements (Sebastian Kiesel)**   
- (22:33 minutes, 10.3 MBytes)   
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/reqs.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/reqs.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-5.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-5.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#reqs](http://www.ietf.org/proceedings/08nov/minutes/alto.html#reqs)
-5. **P4P design and implementation (Richard Yang)**   
- (13:39 minutes, 6.24 MBytes)   
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/p4p.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/p4p.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-2.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-2.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#p4p](http://www.ietf.org/proceedings/08nov/minutes/alto.html#p4p)
+   (1:20 minutes, 625 KBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/administrivia.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/administrivia.mp3)  
+    No slides.  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#agenda](http://www.ietf.org/proceedings/08nov/minutes/alto.html#agenda)
+2. **Status of WG (Lisa Dusseault)**  
+   (5:21 minutes, 2.44 MBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/wg-status.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/wg-status.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-6.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-6.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#status](http://www.ietf.org/proceedings/08nov/minutes/alto.html#status)
+3. **ALTO problem statement (Enrico Marocco)**  
+   (11:06 minutes, 5.08 MBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/ps.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/ps.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-3.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-3.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#ps](http://www.ietf.org/proceedings/08nov/minutes/alto.html#ps)
+4. **ALTO requirements (Sebastian Kiesel)**  
+    (22:33 minutes, 10.3 MBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/reqs.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/reqs.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-5.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-5.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#reqs](http://www.ietf.org/proceedings/08nov/minutes/alto.html#reqs)
+5. **P4P design and implementation (Richard Yang)**  
+    (13:39 minutes, 6.24 MBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/p4p.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/p4p.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-2.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-2.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#p4p](http://www.ietf.org/proceedings/08nov/minutes/alto.html#p4p)
 6. **Comcast's experience in a P4P technical trial (Richard Woundy)**  
-(14:20 minutes, 6.56 MBytes)   
- MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/comcast.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/comcast.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-7.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-7.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#comcast](http://www.ietf.org/proceedings/08nov/minutes/alto.html#comcast)
-7. **ALTO infoexport service (Reinaldo Penno)**   
- (13:55 minutes, 6.37 MBytes)   
-MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/infoexport.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/infoexport.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-1.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-1.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#infoexport](http://www.ietf.org/proceedings/08nov/minutes/alto.html#infoexport)
-8. **Routing proximity (Stefano Previdi)**   
- (15:19 minutes, 7.01 MBytes)   
-MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/routing.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/routing.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-0.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-0.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#routing](http://www.ietf.org/proceedings/08nov/minutes/alto.html#routing)
-9. **Multi-Dimensional Peer Selection Problem (Saumitra Das)**   
- (15:19 minutes, 7.01 MBytes)   
-MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/multi-dim.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/multi-dim.mp3)   
- Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-4.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-4.pdf)  
-Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#multi](http://www.ietf.org/proceedings/08nov/minutes/alto.html#multi)
+   (14:20 minutes, 6.56 MBytes)  
+    MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/comcast.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/comcast.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-7.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-7.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#comcast](http://www.ietf.org/proceedings/08nov/minutes/alto.html#comcast)
+7. **ALTO infoexport service (Reinaldo Penno)**  
+    (13:55 minutes, 6.37 MBytes)  
+   MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/infoexport.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/infoexport.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-1.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-1.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#infoexport](http://www.ietf.org/proceedings/08nov/minutes/alto.html#infoexport)
+8. **Routing proximity (Stefano Previdi)**  
+    (15:19 minutes, 7.01 MBytes)  
+   MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/routing.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/routing.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-0.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-0.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#routing](http://www.ietf.org/proceedings/08nov/minutes/alto.html#routing)
+9. **Multi-Dimensional Peer Selection Problem (Saumitra Das)**  
+    (15:19 minutes, 7.01 MBytes)  
+   MP3:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/multi-dim.mp3](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/multi-dim.mp3)  
+    Slides:[​http://www3.ietf.org/proceedings/08nov/slides/alto-4.pdf](http://www3.ietf.org/proceedings/08nov/slides/alto-4.pdf)  
+   Minutes:[​http://www.ietf.org/proceedings/08nov/minutes/alto.html#multi](http://www.ietf.org/proceedings/08nov/minutes/alto.html#multi)
 
 ---
 
-The raw notes from the session were taken by Volker Hilt and Jan Seedorf. Here are links to the raw notes:   
+The raw notes from the session were taken by Volker Hilt and Jan Seedorf. Here are links to the raw notes:
 
 1. Jan Seedorf:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/raw-notes-seedorf.txt](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/raw-notes-seedorf.txt)
 2. Volker Hilt:[​http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/raw-notes-hilt.txt](http://ect.bell-labs.com/who/vkg/IETF/73/ALTO/raw-notes-hilt.txt)

--- a/group/ALTO/past-meetings/74.md
+++ b/group/ALTO/past-meetings/74.md
@@ -1,135 +1,134 @@
 ---
 title: IETF 74 (March 2009 - San Francisco, CA)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:18.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 74 (March 2009 - San Francisco, CA)
 
 The audio recording corresponding to each agenda item is provided below to help participants track the specific discussion. Also provided is a link to the specific set of slides used during the discussion, and the official minutes as recorded by the note taker. If you scroll down, you will see links for the overflow session as well as the links to the raw minutes recorded by Volker Hilt and Marco Tomsu.
 
 1. **Administrivia (Chairs)**  
-(4:53 minutes, 2.3 MBytes)  
- MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/administrivia.mp3](http://www.standardstrack.com/ietf/alto/ietf74/administrivia.mp3)
+   (4:53 minutes, 2.3 MBytes)  
+    MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/administrivia.mp3](http://www.standardstrack.com/ietf/alto/ietf74/administrivia.mp3)
 
-Slides:[​http://www3.ietf.org/proceedings/09mar/slides/alto-2.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-2.pdf)   
+   Slides:[​http://www3.ietf.org/proceedings/09mar/slides/alto-2.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-2.pdf)
 
-Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#agenda](http://www.ietf.org/proceedings/09mar/minutes/alto.html#agenda)
+   Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#agenda](http://www.ietf.org/proceedings/09mar/minutes/alto.html#agenda)
 
 2. **Problem statement (Eric Burger)**  
-(4:35 minutes, 2.2 MBytes)
+   (4:35 minutes, 2.2 MBytes)
+   MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/problem-statement.mp3](http://www.standardstrack.com/ietf/alto/ietf74/problem-statement.mp3)
 
-MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/problem-statement.mp3](http://www.standardstrack.com/ietf/alto/ietf74/problem-statement.mp3)   
+   Slides: No slides.
 
-Slides: No slides.  
-
-Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#ps](http://www.ietf.org/proceedings/09mar/minutes/alto.html#ps)
+   Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#ps](http://www.ietf.org/proceedings/09mar/minutes/alto.html#ps)
 
 3. **Requirements (Sebastian Kiesel)**  
-(23:01 minutes, 11 MBytes)
+   (23:01 minutes, 11 MBytes)
+   MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/alto-reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf74/alto-reqs.mp3)
 
-MP3:[​http://www.standardstrack.com/ietf/alto/ietf74/alto-reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf74/alto-reqs.mp3)  
+   Slides:[​http://www3.ietf.org/proceedings/09mar/slides/alto-4.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-4.pdf)
 
-Slides:[​http://www3.ietf.org/proceedings/09mar/slides/alto-4.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-4.pdf)   
-
-Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#reqs](http://www.ietf.org/proceedings/09mar/minutes/alto.html#reqs)
+   Minutes:[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#reqs](http://www.ietf.org/proceedings/09mar/minutes/alto.html#reqs)
 
 4. **P4P/Infoexport merged proposal (Richard Yang)**
 
-(15:04 minutes, 7.2 MBytes)  
+(15:04 minutes, 7.2 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/p4p-infoexport.mp3](http://www.standardstrack.com/ietf/alto/ietf74/p4p-infoexport.mp3)  
+    MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/p4p-infoexport.mp3](http://www.standardstrack.com/ietf/alto/ietf74/p4p-infoexport.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-5.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-5.pdf)  
+    Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-5.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-5.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#p4p](http://www.ietf.org/proceedings/09mar/minutes/alto.html#p4p)
+    Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#p4p](http://www.ietf.org/proceedings/09mar/minutes/alto.html#p4p)
 
 5. **PROXIDOR/Oracle (Stefano Previdi and Anja Feldmann)**
 
-(15:55 minutes, 7.6 MBytes)  
+   (15:55 minutes, 7.6 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/proxidor.mp3](http://www.standardstrack.com/ietf/alto/ietf74/proxidor.mp3)  
+   MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/proxidor.mp3](http://www.standardstrack.com/ietf/alto/ietf74/proxidor.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-6.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-6.pdf)  
+   Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-6.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-6.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#proxidor](http://www.ietf.org/proceedings/09mar/minutes/alto.html#proxidor)
+   Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#proxidor](http://www.ietf.org/proceedings/09mar/minutes/alto.html#proxidor)
 
 6. **H1H2/H12 (Martin Stiemerling)**
 
-(8:19 minutes, 3.9 MBytes)  
+   (8:19 minutes, 3.9 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/h1h2-h12.mp3](http://www.standardstrack.com/ietf/alto/ietf74/h1h2-h12.mp3)   
+   MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/h1h2-h12.mp3](http://www.standardstrack.com/ietf/alto/ietf74/h1h2-h12.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-3.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-3.pdf)   
+   Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-3.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-3.pdf)
 
-Minutes: [[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#h1h2](http://www.ietf.org/proceedings/09mar/minutes/alto.html#h1h2)
+   Minutes: [[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#h1h2](http://www.ietf.org/proceedings/09mar/minutes/alto.html#h1h2)
 
 7. **Client to service protocol for ALTO (Saumitra Das)**
 
-(10:05 minutes, 4.8 MBytes)   
+   (10:05 minutes, 4.8 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/saumitra.mp3](http://www.standardstrack.com/ietf/alto/ietf74/saumitra.mp3)   
+   MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/saumitra.mp3](http://www.standardstrack.com/ietf/alto/ietf74/saumitra.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-7.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-7.pdf)   
+   Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-7.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-7.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#cs](http://www.ietf.org/proceedings/09mar/minutes/alto.html#cs)
+   Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#cs](http://www.ietf.org/proceedings/09mar/minutes/alto.html#cs)
 
 8. **ALTO service discovery (Haibin Song and Yu-Shun Wang)**
 
-(19:09 minutes, 9.1 MBytes)   
+   (19:09 minutes, 9.1 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/alto-discovery.mp3](http://www.standardstrack.com/ietf/alto/ietf74/alto-discovery.mp3)   
+   MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/alto-discovery.mp3](http://www.standardstrack.com/ietf/alto/ietf74/alto-discovery.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-8.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-8.pdf)   
+   Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-8.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-8.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#discovery](http://www.ietf.org/proceedings/09mar/minutes/alto.html#discovery)
+   Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#discovery](http://www.ietf.org/proceedings/09mar/minutes/alto.html#discovery)
 
 9. **ALTO and P2P edge-caches (Nicholas Weaver)**
 
-MP3: [None; Nicholas Weaver was not able to present the work.]   
+   MP3: [None; Nicholas Weaver was not able to present the work.]
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-1.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-1.pdf)   
+   Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-1.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-1.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#cache](http://www.ietf.org/proceedings/09mar/minutes/alto.html#cache)
+   Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#cache](http://www.ietf.org/proceedings/09mar/minutes/alto.html#cache)
 
 10. **ATTP (Yunfei Zhang)**
 
-(10:22 minutes, 4.9 MBytes)   
+    (10:22 minutes, 4.9 MBytes)
 
-MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/attp.mp3](http://www.standardstrack.com/ietf/alto/ietf74/attp.mp3)   
+    MP3: [​http://www.standardstrack.com/ietf/alto/ietf74/attp.mp3](http://www.standardstrack.com/ietf/alto/ietf74/attp.mp3)
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-0.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-0.pdf)   
+    Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-0.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-0.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#attp](http://www.ietf.org/proceedings/09mar/minutes/alto.html#attp)
+    Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#attp](http://www.ietf.org/proceedings/09mar/minutes/alto.html#attp)
 
-**IETF 74 Overflow session**   
+**IETF 74 Overflow session**
 
-There wasn't any audio stream for the overflow session. The minutes from
-this session are archived here
-[​http://www.ietf.org/proceedings/09mar/minutes/alto.html#discussion](http://www.ietf.org/proceedings/09mar/minutes/alto.html#discussion)   
+    There wasn't any audio stream for the overflow session. The minutes from
+    this session are archived here
+    [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#discussion](http://www.ietf.org/proceedings/09mar/minutes/alto.html#discussion)
 
-In addition, there was one presentation made towards the end of the session:  
+In addition, there was one presentation made towards the end of the session:
 
-**DNS based IP location service (Syon Ding)**  
+**DNS based IP location service (Syon Ding)**
 
-Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-9.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-9.pdf)   
+    Slides: [​http://www3.ietf.org/proceedings/09mar/slides/alto-9.pdf](http://www3.ietf.org/proceedings/09mar/slides/alto-9.pdf)
 
-Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#dns](http://www.ietf.org/proceedings/09mar/minutes/alto.html#dns)
+    Minutes: [​http://www.ietf.org/proceedings/09mar/minutes/alto.html#dns](http://www.ietf.org/proceedings/09mar/minutes/alto.html#dns)
 
 ---
 
 The raw notes from Marco Tomsu for the regular and overflow session
-are available here:   
+are available here:
 
-Regular session [​http://www.standardstrack.com/ietf/alto/ietf74/alto\_agenda\_mm.doc](http://www.standardstrack.com/ietf/alto/ietf74/alto_agenda_mm.doc)  
+Regular session [​http://www.standardstrack.com/ietf/alto/ietf74/alto_agenda_mm.doc](http://www.standardstrack.com/ietf/alto/ietf74/alto_agenda_mm.doc)
 
-Overflow session [​http://www.standardstrack.com/ietf/alto/ietf74/alto\_follow\_up.doc](http://www.standardstrack.com/ietf/alto/ietf74/alto_follow_up.doc)  
+Overflow session [​http://www.standardstrack.com/ietf/alto/ietf74/alto_follow_up.doc](http://www.standardstrack.com/ietf/alto/ietf74/alto_follow_up.doc)
 
-The raw notes from Volker Hilt are available here:  
+The raw notes from Volker Hilt are available here:
 
-Regular session [​http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-notes-volker.txt](http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-notes-volker.txt)  
+Regular session [​http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-notes-volker.txt](http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-notes-volker.txt)
 
-Overflow session [​http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-s2-notes-volker.txt](http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-s2-notes-volker.txt)  
+Overflow session [​http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-s2-notes-volker.txt](http://www.standardstrack.com/ietf/alto/ietf74/ietf74-alto-s2-notes-volker.txt)

--- a/group/ALTO/past-meetings/75.md
+++ b/group/ALTO/past-meetings/75.md
@@ -1,60 +1,61 @@
 ---
 title: IETF 75 (July 2009 - Stockholm, Sweden)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:17.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 75 (July 2009 - Stockholm, Sweden)
 
 Jabber logs for the session are here:[​http://jabber.ietf.org/logs/alto/2009-07-28.txt](http://jabber.ietf.org/logs/alto/2009-07-28.txt)
 
 1. **Administrivia (Chairs)**
 
-MP3 (3:12 minutes, 1.34 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/administrivia.mp3](http://www.standardstrack.com/ietf/alto/ietf75/administrivia.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-0.pdf](http://www.ietf.org/proceedings/75/slides/alto-0.pdf)   
+   MP3 (3:12 minutes, 1.34 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/administrivia.mp3](http://www.standardstrack.com/ietf/alto/ietf75/administrivia.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#agenda](http://www.ietf.org/proceedings/75/minutes/alto.html#agenda)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-0.pdf](http://www.ietf.org/proceedings/75/slides/alto-0.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#agenda](http://www.ietf.org/proceedings/75/minutes/alto.html#agenda)
 
 2. **Requirements (Sebastian Kiesel)**
 
-MP3 (30:40 minutes, 12.88 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf75/reqs.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-4.pdf](http://www.ietf.org/proceedings/75/slides/alto-4.pdf)   
+   MP3 (30:40 minutes, 12.88 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf75/reqs.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#reqs](http://www.ietf.org/proceedings/75/minutes/alto.html#reqs)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-4.pdf](http://www.ietf.org/proceedings/75/slides/alto-4.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#reqs](http://www.ietf.org/proceedings/75/minutes/alto.html#reqs)
 
 3. **ALTO Protocol Merged Proposal (Reinaldo Penno and Richard Alimi)**
 
-MP3 (48:15 minutes, 20.26 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/protocol.mp3](http://www.standardstrack.com/ietf/alto/ietf75/protocol.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-5.pdf](http://www.ietf.org/proceedings/75/slides/alto-5.pdf)   
+   MP3 (48:15 minutes, 20.26 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/protocol.mp3](http://www.standardstrack.com/ietf/alto/ietf75/protocol.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#proto](http://www.ietf.org/proceedings/75/minutes/alto.html#proto)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-5.pdf](http://www.ietf.org/proceedings/75/slides/alto-5.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#proto](http://www.ietf.org/proceedings/75/minutes/alto.html#proto)
 
 4. **Feedback-based Client Protocol (Zoran Despotovic)**
 
-MP3 (5:59 minutes, 2.51 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/fcp.mp3](http://www.standardstrack.com/ietf/alto/ietf75/fcp.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-1.pdf](http://www.ietf.org/proceedings/75/slides/alto-1.pdf)   
+   MP3 (5:59 minutes, 2.51 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/fcp.mp3](http://www.standardstrack.com/ietf/alto/ietf75/fcp.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#fbcp](http://www.ietf.org/proceedings/75/minutes/alto.html#fbcp)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-1.pdf](http://www.ietf.org/proceedings/75/slides/alto-1.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#fbcp](http://www.ietf.org/proceedings/75/minutes/alto.html#fbcp)
 
 5. **ALTO Server Discovery (Marco Tomsu)**
 
-MP3 (9:50 minutes, 4.13 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/disc.mp3](http://www.standardstrack.com/ietf/alto/ietf75/disc.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-3.pdf](http://www.ietf.org/proceedings/75/slides/alto-3.pdf)   
+   MP3 (9:50 minutes, 4.13 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/disc.mp3](http://www.standardstrack.com/ietf/alto/ietf75/disc.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#disc](http://www.ietf.org/proceedings/75/minutes/alto.html#disc)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-3.pdf](http://www.ietf.org/proceedings/75/slides/alto-3.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#disc](http://www.ietf.org/proceedings/75/minutes/alto.html#disc)
 
 6. **BGP-based ALTO Service (Zoran Despotovic)**
 
-MP3 (8:07 minutes, 3.40 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/bgp.mp3](http://www.standardstrack.com/ietf/alto/ietf75/bgp.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/75/slides/alto-2.pdf](http://www.ietf.org/proceedings/75/slides/alto-2.pdf)   
+   MP3 (8:07 minutes, 3.40 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf75/bgp.mp3](http://www.standardstrack.com/ietf/alto/ietf75/bgp.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#bgp](http://www.ietf.org/proceedings/75/minutes/alto.html#bgp)
+   Slides:[​http://www.ietf.org/proceedings/75/slides/alto-2.pdf](http://www.ietf.org/proceedings/75/slides/alto-2.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/75/minutes/alto.html#bgp](http://www.ietf.org/proceedings/75/minutes/alto.html#bgp)

--- a/group/ALTO/past-meetings/76.md
+++ b/group/ALTO/past-meetings/76.md
@@ -1,86 +1,87 @@
 ---
 title: IETF 76 (November 2009 - Hiroshima, Japan)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:16.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 76 (November 2009 - Hiroshima, Japan)
 
-Jabber logs for the session are here:[​http://jabber.ietf.org/logs/alto/2009-11-11.txt](http://jabber.ietf.org/logs/alto/2009-11-11.txt)
+    Jabber logs for the session are here:[​http://jabber.ietf.org/logs/alto/2009-11-11.txt](http://jabber.ietf.org/logs/alto/2009-11-11.txt)
 
 1. **Administrivia (Chairs)**
 
-MP3 (2:55 minutes, 1.4 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/agenda.mp3](http://www.standardstrack.com/ietf/alto/ietf76/agenda.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-7.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-7.pdf)   
+   MP3 (2:55 minutes, 1.4 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/agenda.mp3](http://www.standardstrack.com/ietf/alto/ietf76/agenda.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#agenda](http://www.ietf.org/proceedings/09nov/minutes/alto.html#agenda)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-7.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-7.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#agenda](http://www.ietf.org/proceedings/09nov/minutes/alto.html#agenda)
 
 2. **Requirements (Richard Woundy)**
 
-MP3 (2:01 minutes, 968 KBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf76/reqs.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-0.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-0.pdf)   
+   MP3 (2:01 minutes, 968 KBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/reqs.mp3](http://www.standardstrack.com/ietf/alto/ietf76/reqs.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#reqs](http://www.ietf.org/proceedings/09nov/minutes/alto.html#reqs)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-0.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-0.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#reqs](http://www.ietf.org/proceedings/09nov/minutes/alto.html#reqs)
 
 3. **Problems with fuzzy IP provisioning, link capacity, etc. (Enrico Marocco)**
 
-MP3 (31:58 minutes, 15.3 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/fuzzy-prov.mp3](http://www.standardstrack.com/ietf/alto/ietf76/fuzzy-prov.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-1.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-1.pdf)   
+   MP3 (31:58 minutes, 15.3 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/fuzzy-prov.mp3](http://www.standardstrack.com/ietf/alto/ietf76/fuzzy-prov.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#maps](http://www.ietf.org/proceedings/09nov/minutes/alto.html#maps)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-1.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-1.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#maps](http://www.ietf.org/proceedings/09nov/minutes/alto.html#maps)
 
 4. **ALTO protocol merged proposal (Richard Alimi)**
 
-MP3 (24:37 minutes, 11.8 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/protocol.mp3](http://www.standardstrack.com/ietf/alto/ietf76/protocol.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-4.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-4.pdf)   
+   MP3 (24:37 minutes, 11.8 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/protocol.mp3](http://www.standardstrack.com/ietf/alto/ietf76/protocol.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#proto](http://www.ietf.org/proceedings/09nov/minutes/alto.html#proto)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-4.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-4.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#proto](http://www.ietf.org/proceedings/09nov/minutes/alto.html#proto)
 
 5. **Aggregate network and cost map into CPID (Haibin Song)**
 
-MP3 (13:49 minutes, 6.6 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/cpid.mp3](http://www.standardstrack.com/ietf/alto/ietf76/cpid.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-6.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-6.pdf)   
+   MP3 (13:49 minutes, 6.6 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/cpid.mp3](http://www.standardstrack.com/ietf/alto/ietf76/cpid.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#cpid](http://www.ietf.org/proceedings/09nov/minutes/alto.html#cpid)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-6.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-6.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#cpid](http://www.ietf.org/proceedings/09nov/minutes/alto.html#cpid)
 
 6. **Third party ALTO server discovery (Martin Stiemerling)**
 
-MP3 (8:07 minutes, 3.40 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/3party-disc.mp3](http://www.standardstrack.com/ietf/alto/ietf76/3party-disc.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-2.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-2.pdf)   
+   MP3 (8:07 minutes, 3.40 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/3party-disc.mp3](http://www.standardstrack.com/ietf/alto/ietf76/3party-disc.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#disco](http://www.ietf.org/proceedings/09nov/minutes/alto.html#disco)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-2.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-2.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#disco](http://www.ietf.org/proceedings/09nov/minutes/alto.html#disco)
 
 7. **Information redistribution (Richard Alimi)**
 
-MP3 (22:43 minutes, 10.9 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/info-redist.mp3](http://www.standardstrack.com/ietf/alto/ietf76/info-redist.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-5.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-5.pdf)   
+   MP3 (22:43 minutes, 10.9 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/info-redist.mp3](http://www.standardstrack.com/ietf/alto/ietf76/info-redist.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#info](http://www.ietf.org/proceedings/09nov/minutes/alto.html#info)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-5.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-5.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#info](http://www.ietf.org/proceedings/09nov/minutes/alto.html#info)
 
 8. **Relay usage in realtime communications (Yu Meng)**
 
-MP3 (25:22 minutes, 12.1 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/relay.mp3](http://www.standardstrack.com/ietf/alto/ietf76/relay.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-3.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-3.pdf)   
+   MP3 (25:22 minutes, 12.1 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/relay.mp3](http://www.standardstrack.com/ietf/alto/ietf76/relay.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#relay](http://www.ietf.org/proceedings/09nov/minutes/alto.html#relay)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-3.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-3.pdf)
 
-NOT ON AGENDA: 
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#relay](http://www.ietf.org/proceedings/09nov/minutes/alto.html#relay)
+
+   NOT ON AGENDA:
 
 9. **Simple ALTO protocol (Martin Stiemerling)**
 
-MP3 (8:32 minutes, 4.0 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/salto.mp3](http://www.standardstrack.com/ietf/alto/ietf76/salto.mp3)   
- 
-Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-8.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-8.pdf)   
+   MP3 (8:32 minutes, 4.0 MBytes):[​http://www.standardstrack.com/ietf/alto/ietf76/salto.mp3](http://www.standardstrack.com/ietf/alto/ietf76/salto.mp3)
 
-Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#salto](http://www.ietf.org/proceedings/09nov/minutes/alto.html#salto)
+   Slides:[​http://www.ietf.org/proceedings/09nov/slides/alto-8.pdf](http://www.ietf.org/proceedings/09nov/slides/alto-8.pdf)
+
+   Minutes:[​http://www.ietf.org/proceedings/09nov/minutes/alto.html#salto](http://www.ietf.org/proceedings/09nov/minutes/alto.html#salto)

--- a/group/ALTO/past-meetings/77.md
+++ b/group/ALTO/past-meetings/77.md
@@ -1,19 +1,20 @@
 ---
 title: IETF 77 (March 2010 - Anaheim, CA)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:15.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 77, Anaheim, CA
 
 The 77th IETF has concluded. ALTO WG met on Monday, Mar 22, 2010.
 The minutes from that working group, including links to slides and
 audio are at the following URL:
 
-[​http://www.ietf.org/proceedings/10mar/minutes/alto.html](http://www.ietf.org/proceedings/10mar/minutes/alto.html)
+- [​http://www.ietf.org/proceedings/10mar/minutes/alto.html](http://www.ietf.org/proceedings/10mar/minutes/alto.html)
 
 Thank you,
 

--- a/group/ALTO/past-meetings/78.md
+++ b/group/ALTO/past-meetings/78.md
@@ -1,16 +1,15 @@
 ---
 title: IETF 78 (July 2010 - Maastricht, Netherlands)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:12.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 78 (July 2010 - Maastricht, Netherlands)
 
 Minutes including links to slides and audio are at the following URL:
 
-> 
 > [​http://www.ietf.org/proceedings/78/minutes/alto.html](http://www.ietf.org/proceedings/78/minutes/alto.html)
-> 

--- a/group/ALTO/past-meetings/79.md
+++ b/group/ALTO/past-meetings/79.md
@@ -1,23 +1,24 @@
 ---
 title: IETF 79 (November 2010 - Beijing, China)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:10.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # IETF 79, Beijing, China
 
 ## Agenda Requests
 
-* ALTO Protocol (Richard Alimi, ??')
-* CDN use case (Richard Alimi, ??')
-* Configuration and monitoring considerations (Xianghui Sun, ??)
-* Xunlei's mechanism in China Telecom trial (Kai Lee, ??')
-* Multi-cost ALTO (Sabine Randriamasy, 10')
-* ALTO requirements (Martin Stiemerling, 5')
-* ALTO server discovery (Martin Stiemerling, 15')
-* ALTO deployment considerations (Martin Stiemerling, 10')
-* ALTO discovery (Song Haibin, ??)
-* Tracker-based peer selection (Richard Yang, 15')
+- ALTO Protocol (Richard Alimi, ??')
+- CDN use case (Richard Alimi, ??')
+- Configuration and monitoring considerations (Xianghui Sun, ??)
+- Xunlei's mechanism in China Telecom trial (Kai Lee, ??')
+- Multi-cost ALTO (Sabine Randriamasy, 10')
+- ALTO requirements (Martin Stiemerling, 5')
+- ALTO server discovery (Martin Stiemerling, 15')
+- ALTO deployment considerations (Martin Stiemerling, 10')
+- ALTO discovery (Song Haibin, ??)
+- Tracker-based peer selection (Richard Yang, 15')

--- a/group/ALTO/past-meetings/91.md
+++ b/group/ALTO/past-meetings/91.md
@@ -1,9 +1,9 @@
 ---
 title: IETF91 (November 2014 -Hawaii, USA)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:09.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
@@ -12,4 +12,4 @@ Meeting Minutes and Materials:
 [​https://tools.ietf.org/wg/alto/minutes?item=minutes-91-alto.html](https://tools.ietf.org/wg/alto/minutes?item=minutes-91-alto.html)
 
 Video Record:
-[​http://recordings.conf.meetecho.com/Playout/watch.jsp?recording=IETF91\_ALTO&chapter=chapter\_0](http://recordings.conf.meetecho.com/Playout/watch.jsp?recording=IETF91_ALTO&chapter=chapter_0)
+[​http://recordings.conf.meetecho.com/Playout/watch.jsp?recording=IETF91_ALTO&chapter=chapter_0](http://recordings.conf.meetecho.com/Playout/watch.jsp?recording=IETF91_ALTO&chapter=chapter_0)

--- a/group/ALTO/past-meetings/92.md
+++ b/group/ALTO/past-meetings/92.md
@@ -1,9 +1,9 @@
 ---
 title: IETF92 (March 2015 - Dallas, USA)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:08.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---

--- a/group/ALTO/past-meetings/93.md
+++ b/group/ALTO/past-meetings/93.md
@@ -1,16 +1,16 @@
 ---
 title: IETF93 (July 2015 - Prague, Czech)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:07.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
 
 [​https://datatracker.ietf.org/meeting/93/proceedings](https://datatracker.ietf.org/meeting/93/proceedings)
 
-Audio Record: [​https://www.ietf.org/audio/ietf93/ietf93-berlin\_brussels-20150721-1520.mp3](https://www.ietf.org/audio/ietf93/ietf93-berlin_brussels-20150721-1520.mp3)
+Audio Record: [​https://www.ietf.org/audio/ietf93/ietf93-berlin_brussels-20150721-1520.mp3](https://www.ietf.org/audio/ietf93/ietf93-berlin_brussels-20150721-1520.mp3)
 
 Meeting Agenda:
 
@@ -23,71 +23,48 @@ Jan Seedorf, Vijay K. Gurbani and Enrico Marocco
 
 1530-1540 - Inter-ALTO communication problem P. Wydrych 10'
 
-> 
 > statement
 > [draft-dulinski-alto-inter-problem-statement-02](http://tools.ietf.org/html/draft-dulinski-alto-inter-problem-statement-02)
-> 
 
 1540-1550 - Path extensions for the ALTO P. Wydrych 10'
 
-> 
 > protocol
 > [draft-wydrych-alto-paths-00](http://tools.ietf.org/html/draft-wydrych-alto-paths-00)
-> 
 
- 
 1550-1600 - Multiple ALTO information sources S. Kiesel 10'
 
-> 
 > and partitioned knowledge
 > [draft-kiesel-alto-xdom-disc](http://tools.ietf.org/html/draft-kiesel-alto-xdom-disc)
-> 
 
 1600-1610 - Extended endpoint properties for H. Song 10'
 
-> 
 > ALTO
 > [draft-deng-alto-p2p-ext-06](http://tools.ietf.org/html/draft-deng-alto-p2p-ext-06)
-> 
 
 1610-1620 - Unified and extensible approach to W. Roome 10'
 
-> 
 > ALTO properties
 > [draft-roome-alto-unified-props-00](http://tools.ietf.org/html/draft-roome-alto-unified-props-00)
-> 
 
 1620-1630 - ALTO map calculation from network H. Seidel 10'
 
-> 
 > data
 > (No internet-draft)
-> 
 
 1630-1640 - Multi-cost ALTO S. Randriamasy 10'
 
-> 
 > [draft-ietf-alto-multi-cost](http://tools.ietf.org/html/draft-ietf-alto-multi-cost)
-> 
 
 1640-1650 - ALTO cost calendar S. Randriamasy 10'
 
-> 
 > [draft-randriamasy-alto-cost-calendar-04](http://tools.ietf.org/html/draft-randriamasy-alto-cost-calendar-04)
-> 
 
- 
 1650-1700 - Routing State Abstraction Service W. Roome / Y.Lee 10'
 
-> 
 > [draft-gao-alto-routing-state-abstraction-00](http://tools.ietf.org/html/draft-gao-alto-routing-state-abstraction-00)
-> 
 
 1700-1710 - Large Data Transfer Coordinator H. Song 10'
 
-> 
 > ddraft-wang-alto-large-data-framework-00
-> 
 
- 
 1710-1720 - Spill over/Conclusion/Wrap-up Chairs/WG 10'

--- a/group/ALTO/past-meetings/96.md
+++ b/group/ALTO/past-meetings/96.md
@@ -1,9 +1,9 @@
 ---
 title: IETF96 (July 2016 - Berlin, Germany)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:04.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
@@ -21,63 +21,40 @@ ALTO WG Meeting, Thu Jul 21, 2016 1400-1600 Charlottenburg I
 
 1405 - 1415 10" Programmable NFV/SDN orchestration with ALTO, L.Bertz
 
-> 
 > [​https://tools.ietf.org/html/draft-bertz-alto-sdnnfvalto-02](https://tools.ietf.org/html/draft-bertz-alto-sdnnfvalto-02)
-> 
 
 1415 - 1430 15" Multi-cost ALTO, ALTO cost calendar, S. Randriamasy
 
-> 
-> [​https://tools.ietf.org/html/draft-ietf-alto-multi-cost-02](https://tools.ietf.org/html/draft-ietf-alto-multi-cost-02)
-> [​https://tools.ietf.org/html/draft-randriamasy-alto-cost-calendar-06](https://tools.ietf.org/html/draft-randriamasy-alto-cost-calendar-06)
-> 
+> [​https://tools.ietf.org/html/draft-ietf-alto-multi-cost-02](https://tools.ietf.org/html/draft-ietf-alto-multi-cost-02) > [​https://tools.ietf.org/html/draft-randriamasy-alto-cost-calendar-06](https://tools.ietf.org/html/draft-randriamasy-alto-cost-calendar-06)
 
 1430 - 1440 10" ALTO for blockchain, S. Hommes
 
-> 
 > [​https://tools.ietf.org/html/draft-hommes-alto-blockchain-01](https://tools.ietf.org/html/draft-hommes-alto-blockchain-01)
-> 
 
 1440 - 1450 10" Traffic optimization for exascale science applications, Q. Xiang
 
-> 
 > [​https://tools.ietf.org/html/draft-xiang-alto-exascale-network-optimization-00](https://tools.ietf.org/html/draft-xiang-alto-exascale-network-optimization-00)
-> 
 
 1450 - 1455 05" ALTO performance cost metrics, Q. Wu
 
-> 
 > [​https://tools.ietf.org/html/draft-wu-alto-te-metrics-08](https://tools.ietf.org/html/draft-wu-alto-te-metrics-08)
-> 
 
 1455 - 1515 20" Path vector and routing state abstraction, R. Yang
 
-> 
-> [​https://tools.ietf.org/html/draft-yang-alto-path-vector-03](https://tools.ietf.org/html/draft-yang-alto-path-vector-03)
-> [​https://tools.ietf.org/html/draft-gao-alto-routing-state-abstraction-03](https://tools.ietf.org/html/draft-gao-alto-routing-state-abstraction-03)
-> 
+> [​https://tools.ietf.org/html/draft-yang-alto-path-vector-03](https://tools.ietf.org/html/draft-yang-alto-path-vector-03) > [​https://tools.ietf.org/html/draft-gao-alto-routing-state-abstraction-03](https://tools.ietf.org/html/draft-gao-alto-routing-state-abstraction-03)
 
 1515 - 1525 10" ALTO flow cost service, R. Yang
 
-> 
 > [​https://tools.ietf.org/html/draft-gao-alto-fcs-00](https://tools.ietf.org/html/draft-gao-alto-fcs-00)
-> 
 
 1525 - 1545 20" Discussion on path vector, ECS, FCS to set WG direction, R. Yang
 
-> 
 > Discussion to be lead by R. Yang with input from WG.
-> 
 
 1545 - 1552 07" ALTO cross-domain server discovery, S. Kiesel
 
-> 
 > [​https://tools.ietf.org/html/draft-kiesel-alto-xdom-disc-02](https://tools.ietf.org/html/draft-kiesel-alto-xdom-disc-02)
-> 
 
- 
 1552 - 1600 08" ALTO experiences with ISP-CDN collaboration, H. Seidel
 
-> 
 > No draft
-> 

--- a/group/ALTO/past-meetings/97.md
+++ b/group/ALTO/past-meetings/97.md
@@ -1,9 +1,9 @@
 ---
 title: IETF97 (November 2016 - Seoul, Korea)
-description: 
+description:
 published: true
 date: 2022-10-26T21:13:03.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---

--- a/group/ALTO/past-meetings/Interim20100616.md
+++ b/group/ALTO/past-meetings/Interim20100616.md
@@ -1,43 +1,44 @@
 ---
 title: Virtual Interim Meeting, June 16,
-                        2010
-description: 
+  2010
+description:
 published: true
 date: 2022-10-26T21:13:13.000Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2022-04-26T13:06:23.000Z
 ---
+
 # Virtual Interim Meeting, June 16, 2010
 
 Wednesday, June 16, 2010 -- 14:00-16:00 UTC
 
 ## Agenda
 
-|  |  |  |
-| --- | --- | --- |
-|  14:00  |  Administrivia  |  Chairs, 10' 
- |
-|  14:10  |  Requirements  |  Sebastian Kiesel, 5' 
- |
-|  14:15  |  ALTO Protocol  |  Richard Alimi, 20' 
- |
-|  14:35  |  Deployment considerations  |  Sebastian Kiesel, 5' 
- |
-|  14:40  |  v4/v6 issues  |  Reinaldo Penno, 10' 
- |
-|  14:50  |  ALTO Discovery  |  Nico Schwan, 15' 
- |
-|  15:05  |  Notification mechanism  |  Wang Aijun, 20' 
- |
-|  15:25  |  ALTO and CDNs  |  Reinaldo Penno, 10' 
- |
-|  15:35  |  Open Discussion / Wrap up  |  WG / Chairs, 5' to 25' 
- |
+|       |                           |                        |
+| ----- | ------------------------- | ---------------------- |
+| 14:00 | Administrivia             | Chairs, 10'            |
+|       |
+| 14:10 | Requirements              | Sebastian Kiesel, 5'   |
+|       |
+| 14:15 | ALTO Protocol             | Richard Alimi, 20'     |
+|       |
+| 14:35 | Deployment considerations | Sebastian Kiesel, 5'   |
+|       |
+| 14:40 | v4/v6 issues              | Reinaldo Penno, 10'    |
+|       |
+| 14:50 | ALTO Discovery            | Nico Schwan, 15'       |
+|       |
+| 15:05 | Notification mechanism    | Wang Aijun, 20'        |
+|       |
+| 15:25 | ALTO and CDNs             | Reinaldo Penno, 10'    |
+|       |
+| 15:35 | Open Discussion / Wrap up | WG / Chairs, 5' to 25' |
+|       |
 
 ## Meeting Notes
 
-This report has been distilled from the detailed meeting notes taken by Jan Seedorf ([attachment:alto-notes-js.txt](/trac/alto/attachment/wiki/Interim20100616/alto-notes-js.txt "Attachment 'alto-notes-js.txt' in Interim20100616")[​](/trac/alto/raw-attachment/wiki/Interim20100616/alto-notes-js.txt "Download")) and Eric Burger ([attachment:alto-notes-eb.txt](/trac/alto/attachment/wiki/Interim20100616/alto-notes-eb.txt "Attachment 'alto-notes-eb.txt' in Interim20100616")[​](/trac/alto/raw-attachment/wiki/Interim20100616/alto-notes-eb.txt "Download")).
+This report has been distilled from the detailed meeting notes taken by Jan Seedorf ([attachment:alto-notes-js.txt](/trac/alto/attachment/wiki/Interim20100616/alto-notes-js.txt "Attachment 'alto-notes-js.txt' in Interim20100616")[​](/trac/alto/raw-attachment/wiki/Interim20100616/alto-notes-js.txt 'Download')) and Eric Burger ([attachment:alto-notes-eb.txt](/trac/alto/attachment/wiki/Interim20100616/alto-notes-eb.txt "Attachment 'alto-notes-eb.txt' in Interim20100616")[​](/trac/alto/raw-attachment/wiki/Interim20100616/alto-notes-eb.txt 'Download')).
 
 Advisor Area Director: Peter Saint-Andre
 
@@ -55,9 +56,7 @@ No questions nor comments.
 
 ALTO server discovery is a chartered item, only one survey draft out yet, hopefully being updated before IETF-78. Add deployment considerations to the charter as agreed in Anaheim. Also need to adjust protocol work items according to current document structure.
 
-> 
 > Richard Alimi: ALTO protocol document is getting large, maybe it should be split up. Extension for notifications is controversial at this point in time, decision on chartering other ALTO extensions postponed for now.
-> 
 
 Chairs and AD will negotiate re-charter milestones.
 
@@ -69,13 +68,9 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-requiremen
 
 Sebastian Kiesel presents the updated requirements document. Since IETF-77 only one new requirement: "target audience" in ALTO reply. Does ALTO follow DNS theory, where all servers deployed in an ISP give same answer to same question, or if ALTO will follow DNS practice, where a regional ALTO server may give a regional response that can differ from an ALTO server in another region? Depending on this, discovery becomes an important consideration in the development of the protocol.
 
-> 
 > Richard: does this put discovery information into the ALTO protocol? Proposal to move some text from requirements draft to deployments draft if the latter becomes a WG item; Peter: the requirements document is looking more like two documents, a requirements document and a rationale / FAQ document. Should we publish the requirements, since they seem stable? Counter-arguments, to keep the requirements document a live document, were that we expect to refine requirements as we get implementation experience. In addition, the CDN exercise may introduce new requirements. Moreover, it is more important to have correct requirements than to have a bone-headed requirement memorialized in an RFC that people than say, "well, we have to implement that because that is what the RFC says."
-> 
 
-> 
 > Vijay: there was a decision in the past to keep the requirements draft an open document for some time. Sebastian: not many changes recently in the requirements draft. Richard: suggests to keep the requirements draft living for some more time. Eric: agrees not to publish it quickly, it is easier to keep it alive for some time.
-> 
 
 ### Protocol (Richard Alimi)
 
@@ -85,15 +80,11 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-protocol.p
 
 Richard presents the updated version of the protocol draft. Lots of discussion as to whether we need to take the current proposed protocol, which is REST-like, to be a full, RESTful protocol. Arguments for making the protocol fully RESTful include the fact the protocol will be much easier to extend and there are a lot of tools available, such as WADL. However, no one really could articulate near-term benefits. Editor's proposal is to remove the term REST from the protocol. Action item is to solicit someone to write an I-D describing what a full RESTful API would look like, so the work group could better make the cost / benefit tradeoff.
 
-> 
 > Discussion among several participants lead to the proposal from the authors to keep the protocol structure the way it is (REST-like), but to also have a separate draft that more concretely describes what the protocol might look like if it were more of a REST-ful protocol. With such a draft, we can more easily judge what the benefits of a REST-ful approach in our context are and whether it makes sense to go that direction.
-> 
 
 Issue: should the protocol split a server query response into a simple server list and a separate server capabilities list? Jon: suggests to keep a single response, in the ALTO document (as opposed to mixing in some HTTP headers).
 
-> 
 > Note: Jon's suggestion was probably in response to the issue of keeping the version number in ALTO Client-Server protocol vs. putting the version number "below" the ALTO Client-Server protocol such as in HTTP headers or the discovery protocol. Jon was (probably) supporting the former option -- should check the audio.
-> 
 
 Issue: status codes (numeric) or names (text) - everyone uses text for debugging. Do we need numeric codes at all? Benefit is a future binary version of ALTO would benefit from having the numeric codes defined already. Taking to the list.
 
@@ -107,9 +98,7 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-deployment
 
 Martin Stiemerling presents the updated individual draft. Goal of the draft is to have a document for any kind of deployment issues, e.g. overloading, also to have a document to answer questions for people new to ALTO.
 
-> 
 > Richard: it is an important draft, but wonders if there is a need for splitting the draft into considerations for a) ISPs/network operators and b) application point of view.
-> 
 
 No further comments, chairs and ADs will decide on how to proceed with chartering a work item for this (hum at IETF-77 for charting an item for this), then the draft can be adopted as a WG item.
 
@@ -121,9 +110,7 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-ipv4ipv6.p
 
 Reinaldo Penno presents the updated individual draft. The issue is where to place an ALTO server (private or public network side)?
 
-> 
 > No feedback nor discussion, further discussion postponed to IETF-78 meeting.
-> 
 
 ### ALTO Server Discovery (Nico Schwan)
 
@@ -133,9 +120,7 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-server-dis
 
 Nico Schwan presents the updated individual draft. Discussion on user configuration requirement (user needs to be able to manually choose a specific ALTO server).
 
-> 
 > Sebastion: this is an important and necessary requirement. Richard: agree.
-> 
 
 Further discussion postponed to the list.
 
@@ -147,9 +132,7 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-server-not
 
 Aijun Wang presents the individual draft. Basically the draft proposes a notification mechanism for servers to actively push ALTO information to clients.
 
-> 
 > Enrico: ALTO is chartered such that the protocol does not care about real-time congestion, this draft seems to propose frequent ALTO information updates (also for congestion control), authors should explain how the draft fits the charter.
-> 
 
 ### ALTO and CDN (Reinaldo Penno)
 
@@ -159,8 +142,6 @@ Slides: [​http://www.standardstrack.com/ietf/alto/alto-interim/alto-cdns.pdf](
 
 Reinaldo presents an individual draft outlining how ALTO can be used for CDN optimization. Discusses CDN HTTP redirect with ALTO and CDN DNS resolution with ALTO.
 
-> 
 > Richard: does the CDN use case require protocol changes or is it more about deployment considerations? Reinaldo: draft will be revised for IETF-78 based on the many comments received.
-> 
 
 ---

--- a/group/alto.md
+++ b/group/alto.md
@@ -21,12 +21,12 @@ https://datatracker.ietf.org/wg/alto/about/
 The WG is using [the Github dashborad](https://github.com/orgs/ietf-wg-alto/projects/1/views/2) to organize the agenda
 of weekly meetings.
 
-- [Draft re-charter (version 0.5 May 8 2021)](/en/group/ALTO/draft/v0.5-recharter)
-- [Draft re-charter (version 0.4 April 1 2021)](/en/group/ALTO/draft/v0.4-recharter)
-- [Draft re-charter (version 0.3 March 18 2021)](/en/group/ALTO/draft/v0.3-recharter)
-- [Draft re-charter (version 0.2, Feb 22 2021)](/en/group/ALTO/draft/v0.2-recharter)
-- [Draft re-charter (version 0.1, Feb 21 2014)](/en/group/ALTO/draft/v0.1-recharter)
-- [Draft re-charter (version 0.0, Feb 19 2014)](/en/group/ALTO/draft/v0.0-recharter)
+- [Draft re-charter (version 0.5 May 8 2021)](/en/group/ALTO/draft/v05)
+- [Draft re-charter (version 0.4 April 1 2021)](/en/group/ALTO/draft/v04)
+- [Draft re-charter (version 0.3 March 18 2021)](/en/group/ALTO/draft/v03)
+- [Draft re-charter (version 0.2, Feb 22 2021)](/en/group/ALTO/draft/v02)
+- [Draft re-charter (version 0.1, Feb 21 2014)](/en/group/ALTO/draft/v01)
+- [Draft re-charter (version 0.0, Feb 19 2014)](/en/group/ALTO/draft/v00)
 
 # Weekly Meeting
 
@@ -74,7 +74,9 @@ meeting reminder notifications.
 - Ietf80 IETF 80 (March 2011 - Prague,Czech)
 - [IETF 79 (November 2010 - Beijing, China)](/en/group/ALTO/past-meetings/79)
 - [IETF 78 (July 2010 - Maastricht, Netherlands)](/en/group/ALTO/past-meetings/78)
-- [Virtual Interim Meeting, June 16, 2010](/en/group/ALTO/past-meetings/Interim20100616)[IETF 77 (March 2010 - Anaheim, CA)](/en/group/ALTO/past-meetings/77)
-- [IETF 76 (November 2009 - Hiroshima, Japan)](/en/group/ALTO/past-meetings/76)[IETF 75 (July 2009 - Stockholm, Sweden)](/en/group/ALTO/past-meetings/75)
+- [Virtual Interim Meeting, June 16, 2010](/en/group/ALTO/past-meetings/Interim20100616)
+- [IETF 77 (March 2010 - Anaheim, CA)](/en/group/ALTO/past-meetings/77)
+- [IETF 76 (November 2009 - Hiroshima, Japan)](/en/group/ALTO/past-meetings/76)
+- [IETF 75 (July 2009 - Stockholm, Sweden)](/en/group/ALTO/past-meetings/75)
 - [IETF 74 (March 2009 - San Francisco, CA)](/en/group/ALTO/past-meetings/74)
 - [IETF 73 (November 2008 - Minneapolis, MN)](/en/group/ALTO/past-meetings/73)


### PR DESCRIPTION
1. Fixed the problem that some file names (eg. ALTO/draft/v0.0 recorder. md) could not be used as URL
2. Updated the document structure of ALTO/draft and ALTO/past-meetings